### PR TITLE
Only build integration test when integration flag specified.

### DIFF
--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integrationtest
 
 import (


### PR DESCRIPTION
This is to avoid the issue where a `go install ./...` attempts to install the test alone which results in an error.
