### PR TITLE
Add atomic write sanity checks.

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,15 @@ func AtomicWrite(path, content string) error {
 	// config.json's containing directory.
 	targetDir := pathLib.Dir(path)
 
+	// Some sanity checking.
+	if path == "" {
+		return fmt.Errorf("AtomicWrite: Path not specified.")
+	}
+	if clean := pathLib.Clean(path); clean == targetDir {
+		return fmt.Errorf("Target path %s (%s) is the target directory %s.",
+			path, clean, targetDir)
+	}
+
 	if tmpFile, err := ioutil.TempFile(targetDir, "provisioner"); err != nil {
 		return err
 	} else {


### PR DESCRIPTION
Checks that the path isn't empty and the target path doesn't resolve to the target directory (i.e. either user specifies a path not a file or the path is a directory itself.)

Ideally we should do a check on whether the path exists too, can add that in a later PR.
