### PR TITLE
We now keep config.json in /mnt/boot.

### DIFF
--- a/cmd/resin-provision/main.go
+++ b/cmd/resin-provision/main.go
@@ -239,7 +239,7 @@ help you manage device fleets.
 
 	p := os.Getenv("CONFIG_PATH")
 	if p == "" {
-		p = "/mnt/conf/config.json"
+		p = "/mnt/boot/config.json"
 	}
 	rootCmd.PersistentFlags().StringVarP(&domain, "domain", "d", "resin.io", "Domain of the API server in which the device will register")
 	rootCmd.PersistentFlags().StringVarP(&configPath, "path", "p", p, "Path for supervisor's config.json")


### PR DESCRIPTION
Simply reference `/mnt/boot/config.json` instead of `/mnt/conf/config.json`.

@agherzan @pcarranzav can you confirm this is where this is now officially being kept?

This fixed an issue where internal server errors were being generated by the API and logged by the supervisor. 
