### PR TITLE
19 Ensure supervisor services get started even if the device is already provisioned

### DIFF
--- a/cmd/resin-provision/main.go
+++ b/cmd/resin-provision/main.go
@@ -222,12 +222,22 @@ help you manage device fleets.
 					return err
 				}
 
+				// Next we need to enable the supervisor systemd service.
+				if conn, err := provisioner.NewDbus(); err != nil {
+					return err
+				} else {
+					defer conn.Close()
+					if err := conn.SupervisorEnableStart(); err != nil {
+						return err
+					}
+				}
+
 				// Since we're just returning a device URL no
 				// point in worrying about the error.
 				if url, err := api.DeviceUrl(); err == nil {
-					fmt.Println("Your device is now provisioned and is "+
+					fmt.Println("Your device is now provisioned and is " +
 						"downloading and installing the resin supervisor.")
-					fmt.Println("Your device will show as configuring during "+
+					fmt.Println("Your device will show as configuring during " +
 						"this process, appearing online once it's complete.")
 					fmt.Printf("\nYou can access the device at:\n%s\n", url)
 				}

--- a/provisioner/api.go
+++ b/provisioner/api.go
@@ -76,6 +76,8 @@ func (a *Api) StateJson() (ret string, err error) {
 func (a *Api) Provision(opts *ProvisionOpts) error {
 	if state, err := a.State(); err != nil {
 		return err
+	} else if state == Provisioned {
+		return nil
 	} else if state != Unprovisioned {
 		return fmt.Errorf("Cannot provision, device is %s.", state)
 	}
@@ -106,18 +108,7 @@ func (a *Api) Provision(opts *ProvisionOpts) error {
 			return err
 		}
 
-		if err := a.writeConfig(conf); err != nil {
-			return err
-		}
-
-		// Next we need to enable the supervisor systemd service.
-		if conn, err := NewDbus(); err != nil {
-			return err
-		} else {
-			defer conn.Close()
-
-			return conn.SupervisorEnableStart()
-		}
+		return a.writeConfig(conf)
 	}
 }
 


### PR DESCRIPTION
Fixes #19 by ensuring that `resin-provisioner` can be run multiple times. 